### PR TITLE
Include primitive JNI signatures

### DIFF
--- a/src/main/java/jdwp/Translator.java
+++ b/src/main/java/jdwp/Translator.java
@@ -229,40 +229,7 @@ public class Translator {
 	}
 
 	public static String getPrimitiveJNI(String param) {
-		String jniParam = "";
-
-		switch (param) {
-			case "":
-				break;
-			case JAVA_BOOLEAN:
-				jniParam = typeSignature.get(JAVA_BOOLEAN);
-				break;
-			case JAVA_BYTE:
-				jniParam = typeSignature.get(JAVA_BYTE);
-				break;
-			case JAVA_CHAR:
-				jniParam = typeSignature.get(JAVA_CHAR);
-				break;
-			case JAVA_SHORT:
-				jniParam = typeSignature.get(JAVA_SHORT);
-				break;
-			case JAVA_INT:
-				jniParam = typeSignature.get(JAVA_INT);
-				break;
-			case JAVA_LONG:
-				jniParam = typeSignature.get(JAVA_LONG);
-				break;
-			case JAVA_FLOAT:
-				jniParam = typeSignature.get(JAVA_FLOAT);
-				break;
-			case JAVA_DOUBLE:
-				jniParam = typeSignature.get(JAVA_DOUBLE);
-				break;
-			case JAVA_VOID:
-				jniParam = typeSignature.get(JAVA_VOID);
-				break;
-		}
-		return jniParam;
+		return typeSignature.get(param);
 	}
 
 	public static LocationImpl locationLookup(String func, int line) {

--- a/src/main/java/jdwp/Translator.java
+++ b/src/main/java/jdwp/Translator.java
@@ -183,6 +183,9 @@ public class Translator {
 			param = param.replace(".", "/");
 			if (!isPrimitive(param)) {
 				param = "L" + param;
+			} else {
+				// If is primitive, provide JNI signature
+				param = getPrimitiveJNI(param);
 			}
 			if (param.contains("[]")) { // array
 				param = param.replace("[]", "");
@@ -201,6 +204,41 @@ public class Translator {
 			}
 		}
 		return start + "(" + newParamList + ")";
+	}
+
+	public static String getPrimitiveJNI(String param) {
+		String jniParam = "";
+
+		switch (param) {
+			case "bool":
+				jniParam = "Z";
+				break;
+			case "byte":
+				jniParam =  "B";
+				break;
+			case "char":
+				jniParam =  "C";
+				break;
+			case "short":
+				jniParam =  "S";
+				break;
+			case "int":
+				jniParam =  "I";
+				break;
+			case "long":
+				jniParam =  "J";
+				break;
+			case "float":
+				jniParam =  "F";
+				break;
+			case "double":
+				jniParam =  "D";
+				break;
+			case "void":
+				jniParam = "V";
+				break;
+		}
+		return jniParam;
 	}
 
 	public static LocationImpl locationLookup(String func, int line) {

--- a/src/test/java/jdwp/TestTranslator.java
+++ b/src/test/java/jdwp/TestTranslator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 IBM Corporation
+ *
+ * This program is free software; you can redistribute and/or modify it under
+ * the terms of the GNU General Public License v2 with Classpath Exception.
+ * The text of the license is available in the file LICENSE.TXT.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See LICENSE.TXT for more details.
+ */
+
+package jdwp;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the Translator class for converting C/C++ info to Java.
+ */
+public class TestTranslator {
+
+    @Test
+    public void testNormalizeFunc() {
+
+        testNormalizePrimitives();
+
+        // Tests objects as parameters
+        String input = "HelloMethod.HelloMethod::main(java.lang.String[] *)";
+        String expected = "HelloMethod/HelloMethod::main([Ljava/lang/String;)";
+        String actual = Translator.normalizeFunc(input);
+        assertEquals("Primitive signature tests for one object parameter", expected, actual);
+    }
+
+    /**
+     * Tests for multiple primitive parameters
+     */
+
+
+    /**
+     * Tests the parameters for all the signatures
+     */
+    @Test
+    public void testNormalizePrimitives() {
+
+        String[] types = new String[]{Translator.JAVA_BOOLEAN, Translator.JAVA_BYTE,
+                Translator.JAVA_CHAR, Translator.JAVA_SHORT,
+                Translator.JAVA_INT, Translator.JAVA_LONG,
+                Translator.JAVA_FLOAT, Translator.JAVA_DOUBLE,
+                Translator.JAVA_VOID};
+        StringBuilder message = new StringBuilder("Primitive signature for boolean should be converted to Z");
+        StringBuilder gdbInput = new StringBuilder("HelloMethod.HelloMethod::hello(boolean)");
+        StringBuilder expected = new StringBuilder("HelloMethod/HelloMethod::hello(Z)");
+        String        actual;
+
+        int msgIndex = 24;                          // the index for b in boolean
+        int inputIndex = gdbInput.indexOf("(") + 1; // the index for b in boolean
+        int expectedIndex = expected.indexOf("(") + 1;
+        int replaceLen = types[0].length();
+
+        for (String currType : types) {
+            // Update boolean and Z in message
+            message.replace(msgIndex, msgIndex + replaceLen, currType);
+            message.replace(message.length() - 1, message.length(), Translator.typeSignature.get(currType));
+
+            // Update parameter type in gdbInput and expected output
+            gdbInput.replace(inputIndex, inputIndex + replaceLen, currType);
+            expected.replace(expectedIndex, expectedIndex + 1, Translator.typeSignature.get(currType));
+            actual = Translator.normalizeFunc(gdbInput.toString());
+            assertEquals(message.toString(), expected.toString(), actual);
+            replaceLen = currType.length();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #65 

- Fixes `Invalid JNI signature "` for `hello(int i)` method call in `HelloMethod`  by filling in translation for primitive parameters (read more below) 
- Primitive arguments and `$asm` variable show up as expected 
- Possible enhancement: may need more testing for translating GDB to JNI signatures 

<img width="449" alt="08-18-22 valid jni signature" src="https://user-images.githubusercontent.com/75508867/185514020-aaca2feb-70d8-478f-b081-8e925c9c999b.png">

**Cause of bug**
* Invalid JNI results from `JDWPMethods-VariablesWithGeneric` retrieving GDB locals and comparing those with the locals obtained from the VM ([here](https://github.com/nativejdb/nativejdb/blob/value/src/main/java/jdwp/JDWPMethod.java#L206))
* Mismatch between GDB and IDE/VM locals led to NativeJDB providing an empty signature on this [line](https://github.com/nativejdb/nativejdb/blob/value/src/main/java/jdwp/JDWPMethod.java#L244)
<img width="1377" alt="08-18-22 gdb and vm var mismatch" src="https://user-images.githubusercontent.com/75508867/185513092-7496cdfc-a717-433f-898c-4e0ae8f16d4b.png">

* Main reason that caused mismatch between VM and GDB variables was that thread frame should be in `hello(int i)` and not `main`
* The list of commands issued for `ThreadReference (11)` is: 
1. FrameCount (7)
2. Name (1)
3. Status (4)
4. Frames (6)
* In FrameCount and Frames, the location of all frames is required. Location includes the JNI signature for the method the frame represents 
* `Translator.locationLookUp` is used to [translate](https://github.com/nativejdb/nativejdb/blob/value/src/main/java/jdwp/Translator.java#L206) GDB's method signature to the one JDWP understands. However, it is missing the translation for primitive parameters like `"int"` to `"I"` 
* Example: GDB provides `HelloMethod.HelloMethod::hello(int)` but JDWP expects `HelloMethod/HelloMethod::hello(I)`

<img width="789" alt="08-18-22 gdb to jni translation" src="https://user-images.githubusercontent.com/75508867/185515909-31b2707e-4ee1-4f78-88f2-202f663febb4.png">

* This PR fixes the problem that primitive parameters like `int` are not translated 
