### PR TITLE
Fix translator method calls

### DIFF
--- a/Dockerfile.qbicc
+++ b/Dockerfile.qbicc
@@ -1,0 +1,46 @@
+FROM ubuntu:22.04
+LABEL maintainer="Ansu Varghese <avarghese@us.ibm.com>"
+
+#Dockerfile input is the address to start the JDWP server on
+ARG ADDRESS_ARG="0.0.0.0:8082"
+#Dockerfile input is the relative path of the debuggee directory
+ARG CLASS_NAME="Hello"
+ARG NATIVE_EXEC="apps/${CLASS_NAME}"
+ARG NATIVE_SRC="apps/${CLASS_NAME}sources"
+ARG IS_QUARKUS="false"
+ARG ASM_LINE="10"
+
+EXPOSE 8082
+HEALTHCHECK CMD wget -q -O /dev/null http://localhost:8080/healthy || exit 1
+
+WORKDIR /jdwp
+
+COPY startProcesses.sh .
+COPY target/NativeJDB-1.0-SNAPSHOT.jar .
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -qqy update \
+    && apt-get -qqy install \
+    build-essential \
+    curl \
+    emacs \
+    valgrind \
+    vim \
+    libunwind-dev \
+    zlib1g-dev
+
+# TODO graalvm should not be needed
+COPY graalvm ./graalvm
+ENV GRAALVM_HOME /jdwp/graalvm
+ENV PATH $PATH:$GRAALVM_HOME/bin
+ENV JAVA_HOME $GRAALVM_HOME
+RUN $GRAALVM_HOME/bin/gu install native-image
+
+ENV ADDRESS_ARG=$ADDRESS_ARG
+ENV CLASS_NAME=$CLASS_NAME
+ENV NATIVE_EXEC=$NATIVE_EXEC
+ENV NATIVE_SRC=$NATIVE_SRC
+ENV IS_QUARKUS=$IS_QUARKUS
+ENV ASM_LINE=$ASM_LINE
+
+ENTRYPOINT ./startProcesses.sh -a $ADDRESS_ARG -c $CLASS_NAME

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ nativejdb: ## Run a JDWPServer to debug a native image executable for CLASS_NAME
 	docker build -t $(JDWPSERVICE) --build-arg CLASS_NAME=$(CLASSNAME) --build-arg NATIVE_EXEC=${NATIVEEXEC} --build-arg NATIVE_SRC=${NATIVESRC} --build-arg IS_QUARKUS=$(ISQUARKUS) --build-arg ASM_LINE=$(ASMLINE) -f Dockerfile .
 	docker run --privileged --name $(JDWPSERVICE) -v $(PWD)/apps:/jdwp/apps -p 8082:8082 -p 8081:8081 $(JDWPSERVICE)
 
+nativejdbqbicc: ## Run a JDWPServer to debug a native image executable for CLASS_NAME app.
+	docker stop $(JDWPSERVICE) && docker rm $(JDWPSERVICE) || exit 0;
+	docker build -t $(JDWPSERVICE) --build-arg CLASS_NAME=$(CLASSNAME) --build-arg NATIVE_EXEC=${NATIVEEXEC}qbicc --build-arg NATIVE_SRC=${NATIVESRC} --build-arg IS_QUARKUS=$(ISQUARKUS) --build-arg ASM_LINE=$(ASMLINE) -f Dockerfile.qbicc .
+	docker run --privileged --name $(JDWPSERVICE) -v $(PWD)/apps:/jdwp/apps -p 8082:8082 -p 8081:8081 $(JDWPSERVICE)
+
 exec: ## Exec into NativeJDB container.
 	docker exec -it $(JDWPSERVICE) /bin/bash
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ NativeJDB uses the [JDWP protocol](https://docs.oracle.com/en/java/javase/11/doc
     - Set Breakpoints (Insert/Enable)
     - Clear Breakpoints (Delete/Disable)
     - Step Over / Step Into / Step Return
-    - Stack Frames information in IDE debugger pane
-    - Variables (Local + Static) values (Work-in-progress)
-    - View of assembly code within a stack frame (work in progress)
+    - Stack Frames information in IDE debugger pane 
+    - Primitive variables (Local + Static) values
+    - View of assembly code within a stack frame
+    - View of variables optimized out by native-image compilation
     - Thread info
 
 ## Requirements
@@ -110,6 +111,13 @@ Set breakpoints in the source code file for your example application in the `nat
 
 On IntelliJ, from the `nativeJDBExamples` open project: Run ---> Edit Configurations --> Remote JVM Debug --> [nativejdbExamples/.run/Hello](https://github.com/nativejdb/nativejdbExamples/blob/main/.run/Hello.run.xml)
 
+###  Additional options to maximize your experience
+
+- Customize the number of assembly instructions using `ASMLINE` flag.
+
+When running `make nativejdb`, specify the `ASMLINE=<num>` flag to modify the number of assembly instructions displayed. If nothing is passed in, it will be defaulted to 10.
+
+Example: `make nativejdb CLASSNAME=HelloNested ASMLINE=20`
 
 ## Current limitations:
 

--- a/src/main/java/gdb/mi/service/command/output/MIFrame.java
+++ b/src/main/java/gdb/mi/service/command/output/MIFrame.java
@@ -42,6 +42,10 @@ public class MIFrame {
 		return (fname.length() != 0) ? fname : file;
 	}
 
+	public String getActualFile() {
+		return file;
+	}
+
 	public String getFullname() {
 		return fullname;
 	}

--- a/src/main/java/jdwp/JDWP.java
+++ b/src/main/java/jdwp/JDWP.java
@@ -51,7 +51,7 @@ public class JDWP {
 
     static Map<Integer, MIFrame> framesById = new HashMap<>();
 
-    static Map<Integer, LocalVariableImpl> localsByID = new HashMap<>();
+    static Map<MIFrame, Map<Integer, LocalVariableImpl>> localsByFrame = new HashMap<>();
 
     static ArrayList<ReferenceTypeImpl> stringClasses = new ArrayList<>();  // get java/lang/String class for asm variable
 

--- a/src/main/java/jdwp/JDWPStackFrame.java
+++ b/src/main/java/jdwp/JDWPStackFrame.java
@@ -29,10 +29,27 @@ import gdb.mi.service.command.commands.MICommand;
 import gdb.mi.service.command.output.*;
 import jdwp.jdi.*;
 
+import java.util.Map;
+
 public class JDWPStackFrame {
     static class StackFrame {
         static final int COMMAND_SET = 16;
         private StackFrame() {}  // hide constructor
+
+        /**
+         * Obtains the frame that has the same function name as the target frame.
+         */
+        private static Map<Integer, LocalVariableImpl> getFrame(MIFrame targetFrame) {
+
+            for (Map.Entry<MIFrame, Map<Integer, LocalVariableImpl>> entry : JDWP.localsByFrame.entrySet()) {
+                String targetFunc = targetFrame.getFunction();
+                MIFrame currFrame = entry.getKey();
+                if (targetFunc.equals(currFrame.getFunction())) {
+                    return entry.getValue();
+                }
+            }
+            return null;
+        }
 
         /**
          * Returns the value of one or more local variables in a
@@ -65,6 +82,7 @@ public class JDWPStackFrame {
                     answer.pkt.errorCode = JDWP.Error.INTERNAL;
                 }
                 MIArg[] vals = replyloc.getVariables();
+                MIFrame topFrame = JDWP.framesById.get(0); // the top-level frame is the current method on the call stack
 
                 int gdbSize = getGDBVariablesSize(vals);
                 answer.writeInt(slots);
@@ -75,7 +93,7 @@ public class JDWPStackFrame {
                     int slot = command.readInt();
                     byte tag = command.readByte();
 
-                    LocalVariableImpl vmVar = JDWP.localsByID.get(slot);
+                    LocalVariableImpl vmVar = getFrame(topFrame).get(slot);
                     MIArg gdbVar = containsInGDBVariables(vals, vmVar.name());
                     if (gdbVar != null) {
                         String value = gdbVar.getValue();
@@ -86,11 +104,14 @@ public class JDWPStackFrame {
                                     answer.writeUntaggedValue(null); //TODO Implement
                                     break;
                                 case JDWP.Tag.BYTE:
+                                    // GDB returns "127 \b"
                                     String[] splited = value.split("\\s+");
                                     answer.writeByte(Byte.parseByte(splited[0]));
                                     break;
                                 case JDWP.Tag.CHAR:
-                                    answer.writeChar(value.charAt(0));
+                                    // GDB returns "97"
+                                    char charValue = (char) Integer.parseInt(value);
+                                    answer.writeChar(charValue);
                                     break;
                                 case JDWP.Tag.FLOAT:
                                     answer.writeFloat(Float.parseFloat(value));
@@ -115,13 +136,13 @@ public class JDWPStackFrame {
                                     break;
                                 case JDWP.Tag.OBJECT:
                                     answer.writeNullObjectRef(); //TODO Implement
+                                    break;
                             }
                         } else if (value.equals("<optimized out>")) {
                             answer.writeByte(JDWP.Tag.STRING);
                             answer.writeObjectRef(JDWP.optimizedVarID); // unique ID for optimized string
                         }
                     } else if (vmVar.name().equals("$asm")) {
-
                         answer.writeByte(JDWP.Tag.STRING);
                         long newAsmId = JDWP.getNewAsmId();
                         answer.writeObjectRef(newAsmId);

--- a/src/main/java/jdwp/JDWPThreadReference.java
+++ b/src/main/java/jdwp/JDWPThreadReference.java
@@ -35,8 +35,6 @@ import java.util.ArrayList;
 
 public class JDWPThreadReference {
 
-
-
     static class ThreadReference {
         static final int COMMAND_SET = 11;
         private ThreadReference() {}  // hide constructor
@@ -251,7 +249,7 @@ public class JDWPThreadReference {
                     int frameId = frame.getLevel();
                     JDWP.framesById.put(frameId, frame);
 
-                    LocationImpl loc = Translator.locationLookup(frame.getFunction(), frame.getLine());
+                    LocationImpl loc = Translator.locationLookup(frame.getActualFile(), frame.getLine());
                     if (loc != null) {
                         framesLength++;
                         locations.add(loc);
@@ -293,7 +291,7 @@ public class JDWPThreadReference {
                 int framesLength = 0;
 
                 for (MIFrame frame: frames) {
-                    LocationImpl loc = Translator.locationLookup(frame.getFunction(), frame.getLine());
+                    LocationImpl loc = Translator.locationLookup(frame.getActualFile(), frame.getLine());
                     if (loc != null) {
                         framesLength++;
                     }

--- a/src/main/java/jdwp/Translator.java
+++ b/src/main/java/jdwp/Translator.java
@@ -11,6 +11,7 @@
 
 package jdwp;
 
+import com.sun.jdi.AbsentInformationException;
 import gdb.mi.service.command.events.*;
 import gdb.mi.service.command.output.MIBreakInsertInfo;
 import gdb.mi.service.command.output.MIResult;
@@ -24,31 +25,6 @@ import jdwp.jdi.ThreadReferenceImpl;
 import java.util.*;
 
 public class Translator {
-
-	static final String JAVA_BOOLEAN = "boolean";
-	static final String JAVA_BYTE = "byte";
-	static final String JAVA_CHAR = "char";
-	static final String JAVA_SHORT = "short";
-	static final String JAVA_INT = "int";
-	static final String JAVA_LONG = "long";
-	static final String JAVA_FLOAT = "float";
-	static final String JAVA_DOUBLE = "double";
-	static final String JAVA_VOID = "void";
-
-	static final Map<String, String> typeSignature;	// primitive type signature mapping from C/C++ to JNI
-	static {
-		typeSignature = new HashMap<>();
-
-		typeSignature.put(JAVA_BOOLEAN, "Z");
-		typeSignature.put(JAVA_BYTE, "B");
-		typeSignature.put(JAVA_CHAR, "C");
-		typeSignature.put(JAVA_SHORT, "S");
-		typeSignature.put(JAVA_INT, "I");
-		typeSignature.put(JAVA_LONG, "J");
-		typeSignature.put(JAVA_FLOAT, "F");
-		typeSignature.put(JAVA_DOUBLE, "D");
-		typeSignature.put(JAVA_VOID, "V");
-	}
 
 	public static PacketStream getVMStartedPacket(GDBControl gc) {
 		PacketStream packetStream = new PacketStream(gc);
@@ -181,83 +157,74 @@ public class Translator {
 		return packetStream;
 	}
 
-	private static  boolean isPrimitive(String type) {
-		return typeSignature.containsKey(type);
-	}
+	/**
+	 * Returns the LocationImpl that belong to the method of the same line given
+	 */
+	public static LocationImpl locationLookup(String func, int line)  {
+		// normalize GDB function name too due to inconsistency in GDB output for getting frames
+		func = normalizeMethodName(func, false);
 
-	public static String normalizeFunc(String func) {
-		StringBuilder finalSignature = new StringBuilder();
+		Map<String, MethodImpl> javaMethods = MethodImpl.methods;
+		Set<String> javaMethodNames = javaMethods.keySet();
 
-		if (!func.contains("(")) { // Function does not contain parameter types
-			return func;
-		}
-		String start = func.substring(0, func.indexOf("(")).replace(".", "/");
-		String paramList = func.substring(func.indexOf("(") + 1, func.indexOf(")"));
-		String[] params = paramList.split(", ");
-		ArrayList<String> newParams = new ArrayList<>();
-		for (String param: params) {
-			if (param.endsWith("*")) { // zero or more param
-				param = param.substring(0, param.indexOf("*")) + ";";
-			}
-			param = param.replace(" ", "");
-			param = param.replace(".", "/");
-			if (!isPrimitive(param)) {
-				param = "L" + param;
-			} else {
-				// If is primitive, provide JNI signature
-				param = getPrimitiveJNI(param);
-			}
-			if (param.contains("[]")) { // array
-				param = param.replace("[]", "");
-				param = "[" + param;
-			}
-			if (!param.equals("void")) {
-				newParams.add(param);
-			}
-		}
-
-		StringBuilder newParamList = new StringBuilder();
-		for (String newParam : newParams) {
-			newParamList.append(newParam);
-		}
-
-		finalSignature.append(start);
-		finalSignature.append("(");
-		finalSignature.append(newParamList);
-		finalSignature.append(")");
-		return finalSignature.toString();
-	}
-
-	public static String getPrimitiveJNI(String param) {
-		return typeSignature.get(param);
-	}
-
-	public static LocationImpl locationLookup(String func, int line) {
-		String name = normalizeFunc(func);
-		MethodImpl impl = MethodImpl.methods.get(name);
-		if (impl != null) {
-			List<LocationImpl> list = ((ConcreteMethodImpl) impl).getBaseLocations().lineMapper.get(line);
-			if (list != null && list.size() >= 1) {
-				return list.get(0);
-			}
-			return null;
-		}
-		if (!name.contains("(")) {
-			Set<String> keys = MethodImpl.methods.keySet();
-			for (String key: keys) {
-				if (key.contains(name)) {
-					ConcreteMethodImpl impl1 = (ConcreteMethodImpl) MethodImpl.methods.get(key);
-					List<LocationImpl> list = ((ConcreteMethodImpl) impl1).getBaseLocations().lineMapper.get(line);
-					if (list != null && list.size() >= 1) {
-						return list.get(0);
+		for (String javaMethodName : javaMethodNames) {
+			String gdbName = normalizeMethodName(javaMethodName, true);
+			if (gdbName.equals(func)) {
+				MethodImpl javaMethod = javaMethods.get(javaMethodName);
+				try {
+					List<LocationImpl> locations = javaMethod.allLineLocations();
+					for (LocationImpl location : locations) {
+						if (location.lineNumber() == line) {
+							return location;
+						}
 					}
+				} catch (AbsentInformationException e) {
+					// move on
 				}
 			}
 		}
 		return null;
 	}
 
+	/**
+	 * Normalizes both GDB and Java method names to contain only filename
+	 */
+	public static String normalizeMethodName(String name, boolean isJava) {
+		if (isJava) {
+			return normalizeJava(name);
+		} else {
+			return normalizeGDB(name);
+		}
+	}
 
+	private static String normalizeGDB(String name) {
+
+		String extension = ".java";
+		String normStr = name;
+
+		// Remove everything after parenthesis
+		if (name.contains(extension)) {
+			int index = name.indexOf(extension);
+			normStr = normStr.substring(0, index);
+		}
+
+		// Replaces `/` with `.`
+		normStr = normStr.replace("/", ".");
+		return normStr;
+	}
+
+	private static String normalizeJava(String name) {
+		String colon = "::";
+		String normStr = name;
+
+		// Remove everything after colon so only filename is left
+		if (name.contains(colon)) {
+			int index = name.indexOf(colon);
+			normStr = normStr.substring(0, index);
+		}
+
+		// Replaces `/` with `.`
+		normStr = normStr.replace("/", ".");
+		return normStr;
+	}
 }
-
-

--- a/src/test/java/jdwp/TestTranslator.java
+++ b/src/test/java/jdwp/TestTranslator.java
@@ -21,55 +21,26 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestTranslator {
 
+    /**
+     * Tests the Translator class for normalizing C/C++ and Java signatures.
+     */
     @Test
     public void testNormalizeFunc() {
+        String gdbFilename = "HelloMethod/HelloMethod.java";
+        String javaNameWithParams = "HelloMethod/HelloMethod::hello(I)";
+        String javaNameWithoutParams = "HelloMethod/HelloMethod::hello()";
+        String expected = "HelloMethod.HelloMethod";
 
-        testNormalizePrimitives();
+        assertEquals("Java and GDB signature of class method should be normalized to the same string",
+                expected,
+                Translator.normalizeMethodName(gdbFilename, false));
 
-        // Tests objects as parameters
-        String input = "HelloMethod.HelloMethod::main(java.lang.String[] *)";
-        String expected = "HelloMethod/HelloMethod::main([Ljava/lang/String;)";
-        String actual = Translator.normalizeFunc(input);
-        assertEquals("Primitive signature tests for one object parameter", expected, actual);
-    }
+        assertEquals("Java and GDB signature of class method should be normalized to the same string",
+                expected,
+                Translator.normalizeMethodName(javaNameWithParams, true));
 
-    /**
-     * Tests for multiple primitive parameters
-     */
-
-
-    /**
-     * Tests the parameters for all the signatures
-     */
-    @Test
-    public void testNormalizePrimitives() {
-
-        String[] types = new String[]{Translator.JAVA_BOOLEAN, Translator.JAVA_BYTE,
-                Translator.JAVA_CHAR, Translator.JAVA_SHORT,
-                Translator.JAVA_INT, Translator.JAVA_LONG,
-                Translator.JAVA_FLOAT, Translator.JAVA_DOUBLE,
-                Translator.JAVA_VOID};
-        StringBuilder message = new StringBuilder("Primitive signature for boolean should be converted to Z");
-        StringBuilder gdbInput = new StringBuilder("HelloMethod.HelloMethod::hello(boolean)");
-        StringBuilder expected = new StringBuilder("HelloMethod/HelloMethod::hello(Z)");
-        String        actual;
-
-        int msgIndex = 24;                          // the index for b in boolean
-        int inputIndex = gdbInput.indexOf("(") + 1; // the index for b in boolean
-        int expectedIndex = expected.indexOf("(") + 1;
-        int replaceLen = types[0].length();
-
-        for (String currType : types) {
-            // Update boolean and Z in message
-            message.replace(msgIndex, msgIndex + replaceLen, currType);
-            message.replace(message.length() - 1, message.length(), Translator.typeSignature.get(currType));
-
-            // Update parameter type in gdbInput and expected output
-            gdbInput.replace(inputIndex, inputIndex + replaceLen, currType);
-            expected.replace(expectedIndex, expectedIndex + 1, Translator.typeSignature.get(currType));
-            actual = Translator.normalizeFunc(gdbInput.toString());
-            assertEquals(message.toString(), expected.toString(), actual);
-            replaceLen = currType.length();
-        }
+        assertEquals("Java and GDB signature of class method should be normalized to the same string",
+                expected,
+                Translator.normalizeMethodName(javaNameWithoutParams, true));
     }
 }


### PR DESCRIPTION
Fixes #67,  #41

## Proposed Changes

- Fix `locationLookUp` in translator method calls so that frame updates smoothly 
- Update README
- Tested with Qbicc apps 

Tested with `HelloMethod`: 
![hellomethod gif](https://user-images.githubusercontent.com/75508867/186726024-fadb0619-db0e-4573-923f-397b901ebecc.gif)

Tested with Quarkus `getting-started`:
<img width="649" alt="08-25-22 quarkus working fine" src="https://user-images.githubusercontent.com/75508867/186726348-93a334ed-ad0a-4c7f-9132-e7fcd3fa9f32.png">

Tested with Qbicc (run using `nativejdbqbicc`: 
- No variables available for the stack frame because VM was unable to load it (could be due to  unsuccessful initial set up of the VM) 
![qbicc](https://user-images.githubusercontent.com/75508867/186726698-64ae18fe-cbf5-40f5-9b98-4604ac48f597.gif)
